### PR TITLE
Add product join to stock queries in selectAll and select functions

### DIFF
--- a/src/db/store/query/stock.js
+++ b/src/db/store/query/stock.js
@@ -90,6 +90,7 @@ export async function selectAll(req, res, next) {
 		})
 		.from(stock)
 		.leftJoin(hrSchema.users, eq(stock.created_by, hrSchema.users.uuid))
+		.leftJoin(product, eq(stock.product_uuid, product.uuid))
 		.orderBy(desc(stock.created_at));
 
 	try {
@@ -123,6 +124,7 @@ export async function select(req, res, next) {
 		})
 		.from(stock)
 		.leftJoin(hrSchema.users, eq(stock.created_by, hrSchema.users.uuid))
+		.leftJoin(product, eq(stock.product_uuid, product.uuid))
 		.where(eq(stock.uuid, req.params.uuid));
 
 	try {


### PR DESCRIPTION
Incorporate product information into stock queries by adding a join to the product table in both the selectAll and select functions.