### PR TITLE
Add joins for floor and rack queries

### DIFF
--- a/src/db/store/query/floor.js
+++ b/src/db/store/query/floor.js
@@ -118,6 +118,7 @@ export async function select(req, res, next) {
 		})
 		.from(floor)
 		.leftJoin(hrSchema.users, eq(floor.created_by, hrSchema.users.uuid))
+		.leftJoin(rack, eq(floor.rack_uuid, rack.uuid))
 		.where(eq(floor.uuid, req.params.uuid));
 
 	try {

--- a/src/db/store/query/rack.js
+++ b/src/db/store/query/rack.js
@@ -117,6 +117,8 @@ export async function select(req, res, next) {
 			remarks: rack.remarks,
 		})
 		.from(rack)
+		.leftJoin(room, eq(rack.room_uuid, room.uuid))
+		.leftJoin(hrSchema.users, eq(rack.created_by, hrSchema.users.uuid))
 		.where(eq(rack.uuid, req.params.uuid));
 
 	try {


### PR DESCRIPTION
Enhance the floor and rack queries by adding joins to include related rack and room data.