### PR TITLE
Remove debug logging from purchase return entry details query

### DIFF
--- a/src/db/store/query/purchase_return.js
+++ b/src/db/store/query/purchase_return.js
@@ -195,8 +195,8 @@ export async function selectPurchaseReturnEntryDetailsByPurchaseReturnUuid(
 			fetchData('/store/purchase-return'),
 			fetchData('/store/purchase-return-entry/by'),
 		]);
-		console.log('purchase_return', purchase_return);
-		console.log('purchase_return_entry', purchase_return_entry);
+		// console.log('purchase_return', purchase_return);
+		// console.log('purchase_return_entry', purchase_return_entry);
 		const response = {
 			...purchase_return?.data,
 			purchase_return_entry: purchase_return_entry?.data || [],


### PR DESCRIPTION
Eliminate unnecessary debug logging to clean up the code and improve readability.