### PR TITLE
Add work routes and problem schema with CRUD operations

### DIFF
--- a/src/db/work/query/problem.js
+++ b/src/db/work/query/problem.js
@@ -1,0 +1,132 @@
+import { desc, eq } from 'drizzle-orm';
+import { handleError, validateRequest } from '../../../util/index.js';
+import db from '../../index.js';
+import * as hrSchema from '../../hr/schema.js';
+import { decimalToNumber } from '../../variables.js';
+
+import { problem } from '../schema.js';
+
+export async function insert(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const problemPromise = db
+		.insert(problem)
+		.values(req.body)
+		.returning({ insertedName: problem.name });
+
+	try {
+		const data = await problemPromise;
+		const toast = {
+			status: 201,
+			type: 'insert',
+			message: `${data[0].insertedName} inserted`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		next(error);
+	}
+}
+
+export async function update(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const problemPromise = db
+		.update(problem)
+		.set(req.body)
+		.where(eq(problem.uuid, req.params.uuid))
+		.returning({ updatedName: problem.name });
+
+	try {
+		const data = await problemPromise;
+		const toast = {
+			status: 201,
+			type: 'update',
+			message: `${data[0].updatedName} updated`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		next(error);
+	}
+}
+
+export async function remove(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const problemPromise = db
+		.delete(problem)
+		.where(eq(problem.uuid, req.params.uuid))
+		.returning({ deletedName: problem.name });
+
+	try {
+		const data = await problemPromise;
+		const toast = {
+			status: 201,
+			type: 'delete',
+			message: `${data[0].deletedName} deleted`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		next(error);
+	}
+}
+
+export async function selectAll(req, res, next) {
+	const problemPromise = db
+		.select({
+			uuid: problem.uuid,
+			name: problem.name,
+			created_by: problem.created_by,
+			created_by_name: hrSchema.users.name,
+			created_at: problem.created_at,
+			updated_at: problem.updated_at,
+			remarks: problem.remarks,
+		})
+		.from(problem)
+		.leftJoin(hrSchema.users, eq(problem.created_by, hrSchema.users.uuid))
+		.orderBy(desc(problem.created_at));
+
+	try {
+		const data = await problemPromise;
+		const toast = {
+			status: 200,
+			type: 'select all',
+			message: 'problems list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		next(error);
+	}
+}
+
+export async function select(req, res, next) {
+	const problemPromise = db
+		.select({
+			uuid: problem.uuid,
+			name: problem.name,
+			created_by: problem.created_by,
+			created_by_name: hrSchema.users.name,
+			created_at: problem.created_at,
+			updated_at: problem.updated_at,
+			remarks: problem.remarks,
+		})
+		.from(problem)
+		.leftJoin(hrSchema.users, eq(problem.created_by, hrSchema.users.uuid))
+		.where(eq(problem.uuid, req.params.uuid));
+
+	try {
+		const data = await problemPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'problem',
+		};
+
+		return await res.status(200).json({ toast, data: data[0] });
+	} catch (error) {
+		next(error);
+	}
+}

--- a/src/db/work/route.js
+++ b/src/db/work/route.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { validateUuidParam } from '../../lib/validator.js';
+
+import * as problemOperations from './query/problem.js';
+
+const workRouter = Router();
+
+//* problem routes *//
+workRouter.get('/problem', problemOperations.selectAll);
+workRouter.get('/problem/:uuid', validateUuidParam(), problemOperations.select);
+workRouter.post('/problem', problemOperations.insert);
+workRouter.put('/problem/:uuid', problemOperations.update);
+workRouter.delete(
+	'/problem/:uuid',
+	validateUuidParam(),
+	problemOperations.remove
+);
+
+export { workRouter };

--- a/src/db/work/schema.js
+++ b/src/db/work/schema.js
@@ -1,0 +1,119 @@
+import {
+	boolean,
+	integer,
+	pgSchema,
+	serial,
+	text,
+	uuid,
+	pgEnum,
+	PgArray,
+} from 'drizzle-orm/pg-core';
+import {
+	DateTime,
+	defaultUUID,
+	PG_DECIMAL,
+	uuid_primary,
+} from '../variables.js';
+
+import * as hrSchema from '../hr/schema.js';
+import * as storeSchema from '../store/schema.js';
+
+const work = pgSchema('work');
+
+export const problem = work.table('problem', {
+	uuid: uuid_primary,
+	name: text('name').notNull(),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	remarks: text('remarks').default(null),
+});
+
+export const order = work.table('order', {
+	id: serial('id').notNull().unique(),
+	uuid: uuid_primary,
+	user_uuid: defaultUUID('user_uuid').references(() => hrSchema.users.uuid),
+	model_uuid: defaultUUID('model_uuid').references(
+		() => storeSchema.model.uuid
+	),
+	size_uuid: defaultUUID('size_uuid').references(() => storeSchema.size.uuid),
+	serial_no: text('serial_no').notNull(),
+	problems_uuid: text('problems_uuid').array(),
+	problem_statement: text('problem_statement').notNull(),
+	accessories: text('accessories').array().default(null),
+	is_product_received: boolean('is_product_received').default(false),
+	receive_date: DateTime('receive_date').default(null),
+	warehouse_uuid: defaultUUID('warehouse_uuid').references(
+		() => storeSchema.warehouse.uuid
+	),
+	rack_uuid: defaultUUID('rack_uuid').references(() => storeSchema.rack.uuid),
+	floor_uuid: defaultUUID('floor_uuid').references(
+		() => storeSchema.floor.uuid
+	),
+	box_uuid: defaultUUID('box_uuid').references(() => storeSchema.box.uuid),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	remarks: text('remarks').default(null),
+});
+
+export const diagnosis = work.table('diagnosis', {
+	id: serial('id').notNull().unique(),
+	uuid: uuid_primary,
+	order_uuid: defaultUUID('order_uuid').references(() => order.uuid),
+	engineer_uuid: defaultUUID('engineer_uuid').references(
+		() => hrSchema.users.uuid
+	),
+	problems_uuid: text('problems_uuid').array(),
+	problem_statement: text('problem_statement').notNull(),
+	status: boolean('status').default(false),
+	status_update_date: DateTime('status_update_date').default(null),
+	proposed_cost: PG_DECIMAL('proposed_cost').default(0),
+	is_proceed_to_repair: boolean('is_proceed_to_repair').default(false),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	remarks: text('remarks').default(null),
+});
+
+export const section = work.table('section', {
+	uuid: uuid_primary,
+	name: text('name').notNull(),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	remarks: text('remarks').default(null),
+});
+
+export const process = work.table('process', {
+	id: serial('id').notNull().unique(),
+	uuid: uuid_primary,
+	section_uuid: defaultUUID('section_uuid').references(() => section.uuid),
+	diagnosis_uuid: defaultUUID('diagnosis_uuid').references(
+		() => diagnosis.uuid
+	),
+	engineer_uuid: defaultUUID('engineer_uuid').references(
+		() => hrSchema.users.uuid
+	),
+	problems_uuid: text('problems_uuid').array(),
+	problem_statement: text('problem_statement').notNull(),
+	status: boolean('status').default(false),
+	status_update_date: DateTime('status_update_date').default(null),
+	is_transferred_for_qc: boolean('is_transferred_for_qc').default(false),
+	is_ready_for_delivery: boolean('is_ready_for_delivery').default(false),
+	warehouse_uuid: defaultUUID('warehouse_uuid').references(
+		() => storeSchema.warehouse.uuid
+	),
+	rack_uuid: defaultUUID('rack_uuid').references(() => storeSchema.rack.uuid),
+	floor_uuid: defaultUUID('floor_uuid').references(
+		() => storeSchema.floor.uuid
+	),
+	box_uuid: defaultUUID('box_uuid').references(() => storeSchema.box.uuid),
+	process_uuid: defaultUUID('process_uuid').references(() => process.uuid),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	remarks: text('remarks').default(null),
+});
+
+export default work;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { hrRouter } from '../db/hr/route.js';
 import { storeRouter } from '../db/store/route.js';
 import { otherRouter } from '../db/others/route.js';
+import { workRouter } from '../db/work/route.js';
 
 const route = express.Router();
 
@@ -24,5 +25,8 @@ route.use('/store', storeRouter);
 
 //* others routes
 route.use('/other', otherRouter);
+
+//* work routes
+route.use('/work', workRouter);
 
 export default route;


### PR DESCRIPTION
Introduce a new problem schema and implement CRUD operations for managing problems. Add corresponding routes to handle requests related to problems within the work module.