### PR TITLE
Add work problem definitions and routes to Swagger documentation

### DIFF
--- a/src/db/store/swagger/def.js
+++ b/src/db/store/swagger/def.js
@@ -1,5 +1,4 @@
 import SE, { SED } from '../../../util/swagger_example.js';
-import { branch, model, warehouse } from '../schema.js';
 
 const defGroup = SED({
 	required: ['uuid', 'name', 'created_at'],

--- a/src/db/work/swagger/def.js
+++ b/src/db/work/swagger/def.js
@@ -1,0 +1,26 @@
+import SE, { SED } from '../../../util/swagger_example.js';
+
+const defProblem = SED({
+	required: ['uuid', 'name', 'created_at'],
+	properties: {
+		uuid: SE.uuid(),
+		name: SE.string('Problem 1'),
+		created_by: SE.uuid(),
+		created_at: SE.date_time(),
+		updated_at: SE.date_time(),
+		remarks: SE.string('remarks'),
+	},
+	xml: 'Work/Problem',
+});
+//* Marge all
+export const defWork = {
+	problem: defProblem,
+};
+
+//* Tag
+export const tagWork = [
+	{
+		name: 'work.problem',
+		description: 'Work Problem',
+	},
+];

--- a/src/db/work/swagger/route.js
+++ b/src/db/work/swagger/route.js
@@ -1,0 +1,110 @@
+import SE from '../../../util/swagger_example.js';
+
+//* Work Problem *//
+
+export const pathWorkProblem = {
+	'/work/problem': {
+		get: {
+			tags: ['work.problem'],
+			summary: 'Get all work problems',
+			responses: {
+				200: SE.response_schema(200, {
+					uuid: SE.uuid(),
+					name: SE.string('work problem name'),
+					created_by: SE.uuid(),
+					created_by_name: SE.string('created_by_name'),
+					created_at: SE.date_time(),
+					updated_at: SE.date_time(),
+					remarks: SE.string('remarks'),
+				}),
+			},
+		},
+		post: {
+			tags: ['work.problem'],
+			summary: 'Create a work problem',
+			requestBody: SE.requestBody_schema_ref('work/problem'),
+			responses: {
+				responses: {
+					200: SE.response_schema_ref(200, 'store/group'),
+					405: SE.response(405),
+				},
+			},
+		},
+	},
+	'/work/problem/{uuid}': {
+		get: {
+			tags: ['work.problem'],
+			summary: 'Get a work problem by uuid',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: 'UUID of the work problem to get',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+				},
+			],
+			responses: {
+				200: SE.response_schema(200, {
+					uuid: SE.uuid(),
+					name: SE.string('work problem name'),
+					created_by: SE.uuid(),
+					created_by_name: SE.string('created_by_name'),
+					created_at: SE.date_time(),
+					updated_at: SE.date_time(),
+					remarks: SE.string('remarks'),
+				}),
+			},
+		},
+		put: {
+			tags: ['work.problem'],
+			summary: 'Update a work problem by uuid',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: 'UUID of the work problem to update',
+					required: true,
+					type: 'string',
+				},
+			],
+			requestBody: SE.requestBody_schema_ref('work/problem'),
+			responses: {
+				responses: {
+					200: SE.response_schema_ref(200, 'store/group'),
+					405: SE.response(405),
+				},
+			},
+		},
+		delete: {
+			tags: ['work.problem'],
+			summary: 'Delete a work problem by uuid',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: 'UUID of the work problem to delete',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+				},
+			],
+			responses: {
+				200: SE.response_schema(200, {
+					uuid: SE.uuid(),
+					name: SE.string('work problem name'),
+					created_by: SE.uuid(),
+					created_by_name: SE.string('created_by_name'),
+					created_at: SE.date_time(),
+					updated_at: SE.date_time(),
+					remarks: SE.string('remarks'),
+				}),
+			},
+		},
+	},
+};
+
+export const pathWork = {
+	...pathWorkProblem,
+};

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -9,21 +9,28 @@ import { pathHr } from './db/hr/swagger/route.js';
 import { defStore, tagStore } from './db/store/swagger/def.js';
 import { pathStore } from './db/store/swagger/route.js';
 
+//* Work
+
+import { defWork, tagWork } from './db/work/swagger/def.js';
+import { pathWork } from './db/work/swagger/route.js';
+
 //* Others
 
 import { pathOthers, tagOthers } from './db/others/swagger/route.js';
 
-const tags = [...tagHr, ...tagStore, ...tagOthers];
+const tags = [...tagHr, ...tagStore, ...tagOthers, ...tagWork];
 
 const definitions = {
 	hr: defHr,
 	store: defStore,
+	work: defWork,
 };
 
 const paths = {
 	...pathHr,
 	...pathStore,
 	...pathOthers,
+	...pathWork,
 };
 
 const swaggerSpec = swaggerJSDoc({


### PR DESCRIPTION
Introduce definitions and routes for work problems in the Swagger documentation, enhancing API clarity and usability.