### PR TITLE
Add left join for purchase in purchase_entry query

### DIFF
--- a/src/db/store/query/purchase_entry.js
+++ b/src/db/store/query/purchase_entry.js
@@ -173,6 +173,7 @@ export async function select(req, res, next) {
 		.leftJoin(floor, eq(purchase_entry.floor_uuid, floor.uuid))
 		.leftJoin(box, eq(purchase_entry.box_uuid, box.uuid))
 		.leftJoin(stock, eq(purchase_entry.stock_uuid, stock.uuid))
+		.leftJoin(purchase, eq(purchase_entry.purchase_uuid, purchase.uuid))
 		.where(eq(purchase_entry.uuid, req.params.uuid));
 
 	try {


### PR DESCRIPTION
Incorporate a left join for the purchase table in the select query of purchase_entry to enhance data retrieval.