### PR TITLE
Insert diagnosis after order creation and update schema

### DIFF
--- a/src/db/trigger/diagnosis_after_order.sql
+++ b/src/db/trigger/diagnosis_after_order.sql
@@ -1,0 +1,28 @@
+
+CREATE OR REPLACE FUNCTION generate_15_digit_uuid()
+RETURNS VARCHAR AS $$
+DECLARE
+    result VARCHAR;
+BEGIN
+    SELECT substring(md5(random()::text), 1, 15) INTO result;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION insert_diagnosis_after_order()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.is_product_received = true THEN
+        INSERT INTO work.diagnosis (order_uuid, uuid, created_at, updated_at)
+        VALUES (NEW.uuid, generate_15_digit_uuid(), new.created_at, new.updated_at);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+
+CREATE OR REPLACE TRIGGER after_order_insert_update
+AFTER INSERT OR UPDATE ON work.order
+FOR EACH ROW
+EXECUTE FUNCTION insert_diagnosis_after_order();

--- a/src/db/work/schema.js
+++ b/src/db/work/schema.js
@@ -71,7 +71,7 @@ export const diagnosis = work.table('diagnosis', {
 		() => hrSchema.users.uuid
 	),
 	problems_uuid: text('problems_uuid').array(),
-	problem_statement: text('problem_statement').notNull(),
+	problem_statement: text('problem_statement'),
 	status: statusEnum('status').default('pending'),
 	status_update_date: DateTime('status_update_date').default(null),
 	proposed_cost: PG_DECIMAL('proposed_cost').default(0),


### PR DESCRIPTION
Add a trigger and function to insert a diagnosis record automatically after an order is created or updated, provided the product has been received. Additionally, modify the `problem_statement` field in the diagnosis schema to allow null values.