### PR TITLE
Add endpoints for fetching diagnosis details by order UUID

### DIFF
--- a/src/db/work/route.js
+++ b/src/db/work/route.js
@@ -7,6 +7,7 @@ import * as diagnosisOperations from './query/diagnosis.js';
 import * as sectionOperations from './query/section.js';
 import * as processOperations from './query/process.js';
 
+
 const workRouter = Router();
 
 //* problem routes *//
@@ -26,6 +27,10 @@ workRouter.get('/order/:uuid', validateUuidParam(), orderOperations.select);
 workRouter.post('/order', orderOperations.insert);
 workRouter.put('/order/:uuid', orderOperations.update);
 workRouter.delete('/order/:uuid', validateUuidParam(), orderOperations.remove);
+workRouter.get(
+	'/diagnosis-details-by-order/:order_uuid',
+	orderOperations.selectDiagnosisDetailsByOrder
+);
 
 //* diagnosis routes *//
 workRouter.get('/diagnosis', diagnosisOperations.selectAll);
@@ -40,6 +45,10 @@ workRouter.delete(
 	'/diagnosis/:uuid',
 	validateUuidParam(),
 	diagnosisOperations.remove
+);
+workRouter.get(
+	'/diagnosis-by-order/:order_uuid',
+	diagnosisOperations.selectByOrder
 );
 
 //* section routes *//

--- a/src/db/work/swagger/route.js
+++ b/src/db/work/swagger/route.js
@@ -1,4 +1,5 @@
 import SE from '../../../util/swagger_example.js';
+import { diagnosis } from '../schema.js';
 
 //* Work Problem *//
 
@@ -267,6 +268,72 @@ export const pathWorkOrder = {
 			},
 		},
 	},
+	'/work/diagnosis-details-by-order/{order_uuid}': {
+		get: {
+			tags: ['work.order'],
+			summary: 'Get diagnosis details by order uuid',
+			parameters: [
+				{
+					name: 'order_uuid',
+					in: 'path',
+					description: 'UUID of the order to get diagnosis details',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+				},
+			],
+			responses: {
+				200: SE.response_schema(200, {
+					id: SE.integer(),
+					order_id: SE.string('WO25-0001'),
+					uuid: SE.uuid(),
+					user_uuid: SE.uuid(),
+					model_uuid: SE.uuid(),
+					model_name: SE.string('model_name'),
+					size_uuid: SE.uuid(),
+					size_name: SE.string('size_name'),
+					serial_no: SE.string('serial_no'),
+					problems_uuid: SE.array(),
+					problem_statement: SE.string('problem_statement'),
+					accessories: SE.array(),
+					is_product_received: SE.boolean(),
+					receive_date: SE.date_time(),
+					warehouse_uuid: SE.uuid(),
+					warehouse_name: SE.string('warehouse_name'),
+					rack_uuid: SE.uuid(),
+					rack_name: SE.string('rack_name'),
+					floor_uuid: SE.uuid(),
+					floor_name: SE.string('floor_name'),
+					box_uuid: SE.uuid(),
+					box_name: SE.string('box_name'),
+					created_by: SE.uuid(),
+					created_by_name: SE.string('created_by_name'),
+					created_at: SE.date_time(),
+					updated_at: SE.date_time(),
+					remarks: SE.string('remarks'),
+					diagnosis: SE.array({
+						id: SE.integer(),
+						diagnosis_id: SE.string('WD25-0001'),
+						uuid: SE.uuid(),
+						order_uuid: SE.uuid(),
+						order_id: SE.string('WO25-0001'),
+						engineer_uuid: SE.uuid(),
+						problems_uuid: SE.array(),
+						problem_statement: SE.string('problem_statement'),
+						status: SE.boolean(),
+						status_update_date: SE.date_time(),
+						proposed_cost: SE.number(),
+						is_proceed_to_repair: SE.boolean(),
+						created_by: SE.uuid(),
+						created_by_name: SE.string('created_by_name'),
+						created_at: SE.date_time(),
+						updated_at: SE.date_time(),
+						remarks: SE.string('remarks'),
+					}),
+				}),
+			},
+		},
+	},
 };
 
 export const pathWorkDiagnosis = {
@@ -280,6 +347,7 @@ export const pathWorkDiagnosis = {
 					diagnosis_id: SE.string('WD25-0001'),
 					uuid: SE.uuid(),
 					order_uuid: SE.uuid(),
+					order_id: SE.string('WO25-0001'),
 					engineer_uuid: SE.uuid(),
 					problems_uuid: SE.array(),
 					problem_statement: SE.string('problem_statement'),
@@ -327,6 +395,7 @@ export const pathWorkDiagnosis = {
 					diagnosis_id: SE.string('WD25-0001'),
 					uuid: SE.uuid(),
 					order_uuid: SE.uuid(),
+					order_id: SE.string('WO25-0001'),
 					engineer_uuid: SE.uuid(),
 					problems_uuid: SE.array(),
 					problem_statement: SE.string('problem_statement'),
@@ -370,6 +439,43 @@ export const pathWorkDiagnosis = {
 					name: 'uuid',
 					in: 'path',
 					description: 'UUID of the work diagnosis to delete',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+				},
+			],
+			responses: {
+				200: SE.response_schema(200, {
+					id: SE.integer(),
+					diagnosis_id: SE.string('WD25-0001'),
+					uuid: SE.uuid(),
+					order_uuid: SE.uuid(),
+					engineer_uuid: SE.uuid(),
+					problems_uuid: SE.array(),
+					problem_statement: SE.string('problem_statement'),
+					status: SE.boolean(),
+					status_update_date: SE.date_time(),
+					proposed_cost: SE.number(),
+					is_proceed_to_repair: SE.boolean(),
+					created_by: SE.uuid(),
+					created_by_name: SE.string('created_by_name'),
+					created_at: SE.date_time(),
+					updated_at: SE.date_time(),
+					remarks: SE.string('remarks'),
+				}),
+			},
+		},
+	},
+
+	'/work/diagnosis-by-order/{order_uuid}': {
+		get: {
+			tags: ['work.diagnosis'],
+			summary: 'Get a work diagnosis by order uuid',
+			parameters: [
+				{
+					name: 'order_uuid',
+					in: 'path',
+					description: 'UUID of the order to get diagnosis',
 					required: true,
 					type: 'string',
 					format: 'uuid',


### PR DESCRIPTION
Introduce new endpoints to retrieve diagnosis details and a list of diagnoses associated with a specific order UUID. This enhances the API's functionality for better data retrieval related to orders.