### PR TITLE
Add brand information to order response in select function

### DIFF
--- a/src/db/work/query/order.js
+++ b/src/db/work/query/order.js
@@ -176,6 +176,8 @@ export async function select(req, res, next) {
 			created_at: order.created_at,
 			updated_at: order.updated_at,
 			remarks: order.remarks,
+			brand_uuid: storeSchema.model.brand_uuid,
+			brand_name: storeSchema.brand.name,
 		})
 		.from(order)
 		.leftJoin(hrSchema.users, eq(order.created_by, hrSchema.users.uuid))
@@ -195,6 +197,10 @@ export async function select(req, res, next) {
 		)
 		.leftJoin(storeSchema.box, eq(order.box_uuid, storeSchema.box.uuid))
 		.leftJoin(user, eq(order.user_uuid, user.uuid))
+		.leftJoin(
+			storeSchema.brand,
+			eq(storeSchema.model.brand_uuid, storeSchema.brand.uuid)
+		)
 		.where(eq(order.uuid, req.params.uuid));
 
 	try {


### PR DESCRIPTION
Include brand UUID and name in the order response to enhance the data returned by the select function.