### PR TITLE
Add user_type property to HR user definition and route

### DIFF
--- a/src/db/hr/swagger/def.js
+++ b/src/db/hr/swagger/def.js
@@ -36,6 +36,7 @@ export const defHrUser = SED({
 		'can_access',
 		'created_at',
 		'status',
+		'user_type',
 	],
 	properties: {
 		uuid: SE.uuid(),
@@ -51,6 +52,7 @@ export const defHrUser = SED({
 		updated_at: SE.date_time(),
 		status: SE.string('active'),
 		remarks: SE.string('remarks'),
+		user_type: SE.string('employee'),
 	},
 	xml: 'Hr/User',
 });

--- a/src/db/hr/swagger/route.js
+++ b/src/db/hr/swagger/route.js
@@ -112,6 +112,7 @@ export const pathHrUser = {
 				updated_at: SE.date_time(),
 				status: SE.integer(1),
 				remarks: SE.string('remarks'),
+				user_type: SE.string('employee'),
 			}),
 			responses: {
 				200: {


### PR DESCRIPTION
Introduce a user_type property to the HR user definition and update the corresponding route to include this new property.