### PR TITLE
Refactor selectAll for correct data formatting

### DIFF
--- a/src/db/work/query/process.js
+++ b/src/db/work/query/process.js
@@ -309,7 +309,7 @@ export async function selectAll(req, res, next) {
 		};
 
 		const formattedDataWithId = {
-			...resultIdData,
+			...resultIdData[0],
 			entry: formattedData,
 		};
 


### PR DESCRIPTION
Adjust the `selectAll` function to spread the first element of `resultIdData`, ensuring proper data formatting.